### PR TITLE
universal implicit solution

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,13 @@ app.set('view engine', 'hbs');
 /**
  * Routes for OpenID Connect service
  */
-app.get('/auth/callback', passport.authenticate('oidc', {
+app.get('/auth/callback', (req, res, next) => {
+  if (process.env.RESPONSE_TYPE && process.env.RESPONSE_TYPE.includes('token')) { // implicit but form_post is not used
+    res.render('repost');
+  } else {
+    next();
+  }
+}, passport.authenticate('oidc', {
   failureRedirect: '/',
   successRedirect: '/profile',
 }));
@@ -82,4 +88,3 @@ if (process.env.FORCE_SSL && fs.existsSync(process.env.KEY || './https.key') && 
     debug(`App listening on port ${process.env.PORT || 3000}`);
   });
 }
-

--- a/views/repost.hbs
+++ b/views/repost.hbs
@@ -1,0 +1,36 @@
+<html>
+  <head>
+    <title>OpenID Connect Test</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      function parseQuery(queryString) {
+        var query = {};
+        var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+        for (var i = 0; i < pairs.length; i++) {
+            var pair = pairs[i].split('=');
+            query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+        }
+        return query;
+      }
+      
+      var fields = parseQuery(window.location.hash.substring(1));
+      
+      const form = document.createElement('form');
+      form.method = 'POST';
+
+      Object.keys(fields).forEach((key) => {
+        if (key) { // empty fragment will yield {"":""};
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = key;
+          input.value = fields[key];
+          form.appendChild(input);
+        }
+      });
+
+      document.body.appendChild(form);
+      form.submit();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
When response type includes token (`id_token`, `id_token token`, `code token`, `code id_token`, `code id_token token`) and `response_mode=form_post` is not used (i.e. when not supported by the OP) don't authenticate and instead render a view that parses the fragment and reposts to the POST route.

This solution works for all providers regardless of whether they support form_post or not.

I also think it'd be great if the solution was discovering issuers that support the discovery spec, in that case i'd only provide the ISSUER env variable, not the others.